### PR TITLE
feat: [PM-13/14/15] Created pre configured values for requests

### DIFF
--- a/common/data/src/main/java/io/lb/common/data/model/MappedRoute.kt
+++ b/common/data/src/main/java/io/lb/common/data/model/MappedRoute.kt
@@ -11,6 +11,9 @@ import java.util.UUID
  * @property mappedApi The mapped API.
  * @property originalRoute The original route.
  * @property method The HTTP method of the mapped route.
+ * @property preConfiguredQueries The pre-configured queries of the mapped route.
+ * @property preConfiguredHeaders The pre-configured headers of the mapped route.
+ * @property preConfiguredBody The pre-configured body of the mapped route.
  * @property rulesAsString The mapping rules as a string.
  * <br>Json example of the rules:
  * <br>[RulesExample.json](https://github.com/LeonardoBai12-Org/ProjectMiddleware/blob/main/JsonExamples/RulesExample.json)
@@ -22,5 +25,8 @@ data class MappedRoute(
     val mappedApi: MappedApi,
     val originalRoute: OriginalRoute,
     val method: MiddlewareHttpMethods,
+    val preConfiguredQueries: Map<String, String> = mapOf(),
+    val preConfiguredHeaders: Map<String, String> = originalRoute.headers,
+    val preConfiguredBody: String? = originalRoute.body,
     val rulesAsString: String?
 )

--- a/common/data/src/main/java/io/lb/common/data/model/OriginalRoute.kt
+++ b/common/data/src/main/java/io/lb/common/data/model/OriginalRoute.kt
@@ -19,5 +19,5 @@ data class OriginalRoute(
     val method: MiddlewareHttpMethods,
     val authHeader: MiddlewareAuthHeader? = null,
     val headers: Map<String, String> = mapOf(),
-    val body: String?
+    val body: String? = null
 )

--- a/common/data/src/main/java/io/lb/common/data/service/ClientService.kt
+++ b/common/data/src/main/java/io/lb/common/data/service/ClientService.kt
@@ -13,10 +13,18 @@ interface ClientService {
      * Makes a request to the middleware server.
      *
      * @param route The route to request.
-     * @param queries The queries to include in the request.
+     * @param preConfiguredQueries The pre-configured queries to include in the request.
+     * @param preConfiguredHeaders The pre-configured headers to include in the request.
+     * @param preConfiguredBody The pre-configured body to include in the request.
+     *
      * @return The response from the middleware server.
      */
-    suspend fun request(route: OriginalRoute, queries: Map<String, String>): OriginalResponse
+    suspend fun request(
+        route: OriginalRoute,
+        preConfiguredQueries: Map<String, String>,
+        preConfiguredHeaders: Map<String, String>,
+        preConfiguredBody: String?
+    ): OriginalResponse
 
     /**
      * Validates an API by making a request to the base URL.

--- a/impl/ktor-client/src/main/kotlin/io/lb/impl/ktor/client/service/ClientServiceImpl.kt
+++ b/impl/ktor-client/src/main/kotlin/io/lb/impl/ktor/client/service/ClientServiceImpl.kt
@@ -17,8 +17,18 @@ import io.lb.impl.ktor.client.util.request
 internal class ClientServiceImpl(
     private val client: HttpClient
 ) : ClientService {
-    override suspend fun request(route: OriginalRoute, queries: Map<String, String>): OriginalResponse {
-        return client.request(route, queries)
+    override suspend fun request(
+        route: OriginalRoute,
+        preConfiguredQueries: Map<String, String>,
+        preConfiguredHeaders: Map<String, String>,
+        preConfiguredBody: String?
+    ): OriginalResponse {
+        return client.request(
+            originalRoute = route,
+            preConfiguredQueries = preConfiguredQueries,
+            preConfiguredHeaders = preConfiguredHeaders,
+            preConfiguredBody = preConfiguredBody
+        )
     }
 
     override suspend fun validateApi(api: OriginalApi): ApiValidationResponse {

--- a/impl/mongo-database/src/main/kotlin/io/lb/impl/mongo/database/model/MappedRouteEntity.kt
+++ b/impl/mongo-database/src/main/kotlin/io/lb/impl/mongo/database/model/MappedRouteEntity.kt
@@ -13,14 +13,20 @@ import java.util.UUID
  * @property path The path of the route.
  * @property originalRoute The original route.
  * @property method The HTTP method.
- * @property body The body.
+ * @property preConfiguredQueries Pre-configured queries.
+ * @property preConfiguredHeaders Pre-configured headers.
+ * @property preConfiguredBody Pre-configured body.
+ * @property rulesAsString The mapping rules as a string.
  */
 data class MappedRouteEntity(
     val uuid: UUID,
     val path: String,
     val originalRoute: OriginalRoute,
     val method: MiddlewareHttpMethods,
-    val body: String?
+    val preConfiguredQueries: Map<String, String>,
+    val preConfiguredHeaders: Map<String, String>,
+    val preConfiguredBody: String?,
+    val rulesAsString: String?,
 ) {
     /**
      * Converts the entity to a mapped route.
@@ -35,7 +41,10 @@ data class MappedRouteEntity(
             mappedApi = mappedApi,
             originalRoute = this.originalRoute,
             method = this.method,
-            rulesAsString = this.body,
+            preConfiguredQueries = this.preConfiguredQueries,
+            preConfiguredHeaders = this.preConfiguredHeaders,
+            preConfiguredBody = this.preConfiguredBody,
+            rulesAsString = this.rulesAsString,
         )
     }
 }
@@ -51,6 +60,9 @@ internal fun MappedRoute.toEntity(): MappedRouteEntity {
         path = path,
         originalRoute = originalRoute,
         method = method,
-        body = rulesAsString,
+        preConfiguredQueries = this.preConfiguredQueries,
+        preConfiguredHeaders = this.preConfiguredHeaders,
+        preConfiguredBody = this.preConfiguredBody,
+        rulesAsString = rulesAsString,
     )
 }

--- a/impl/mongo-database/src/test/kotlin/io/lb/impl/mongo/databases/service/DatabaseServiceImplTest.kt
+++ b/impl/mongo-database/src/test/kotlin/io/lb/impl/mongo/databases/service/DatabaseServiceImplTest.kt
@@ -14,15 +14,15 @@ import io.lb.common.shared.error.MiddlewareException
 import io.lb.impl.mongo.database.model.MappedApiEntity
 import io.lb.impl.mongo.database.model.MappedRouteEntity
 import io.lb.impl.mongo.database.service.DatabaseServiceImpl
-import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.mockk
+import io.mockk.unmockkAll
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.bson.conversions.Bson
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -32,16 +32,20 @@ import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 class DatabaseServiceImplTest {
-    @RelaxedMockK
     private lateinit var db: MongoDatabase
     private lateinit var collection: MongoCollection<MappedApiEntity>
     private lateinit var service: DatabaseService
 
     @BeforeEach
     fun setUp() {
-        MockKAnnotations.init(this)
+        db = mockk(relaxed = true)
         collection = db.getCollection("MappedApi")
         service = DatabaseServiceImpl(db)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
     }
 
     @Test
@@ -279,7 +283,7 @@ class DatabaseServiceImplTest {
         val apiUuid = UUID.randomUUID()
         val updatedApi = MappedApi(apiUuid, OriginalApi("https://test.com"), "Updated API")
 
-        mockFindApi(emptyList<MappedApiEntity>())
+        mockFindApi(emptyList())
 
         val exception = assertThrows<MiddlewareException> {
             service.updateMappedApi(updatedApi)
@@ -342,7 +346,10 @@ class DatabaseServiceImplTest {
             originalApi = OriginalApi("https://teste.com")
         ),
         method = MiddlewareHttpMethods.Get,
-        body = null,
+        preConfiguredQueries = mapOf("query" to "value"),
+        preConfiguredHeaders = mapOf("header" to "value"),
+        preConfiguredBody = "",
+        rulesAsString = null,
     )
 
     private fun mappedRoute() = mappedRouteEntity()


### PR DESCRIPTION
## Description

- **What does this PR do?**  
  - Created pre configured values for requests

- **Related Issue:**  
  - https://lbio.youtrack.cloud/issue/PM-13/FeatureClient-Add-Support-for-Pre-Configured-Parameters
  - https://lbio.youtrack.cloud/issue/PM-14/FeatureClient-Add-Support-for-Pre-Configured-Body
  - https://lbio.youtrack.cloud/issue/PM-15/FeatureClient-Add-Support-for-Pre-Configured-Headers-Use-Original-by-Default-Even-if-Null

## Changes

- **What's been added, removed, or fixed?**  
  - Add Support for Pre-Configured Headers - Use Original by Default, Even if Null
  - Add Support for Pre-Configured Parameters
  - Add Support for Pre-Configured Body 
  - Created unit tests for these cases

## Checklist

- [x] Code follows project guidelines.
- [x] Tests added or updated.
- [x] All tests pass.
- [x] YouTrack issue linked.

---

Thank you!
