### PR TITLE
Add CD pipeline to deploy to Fly.io on release

### DIFF
--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -1,0 +1,32 @@
+name: Deploy to Fly.io
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: 17
+          distribution: 'adopt'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build fat JAR
+        run: ./gradlew clean shadowJar --no-daemon
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy_workflow.yml` that triggers on GitHub release published events
- Builds the fat JAR via `./gradlew shadowJar`, then deploys to Fly.io using `flyctl deploy --remote-only`
- Requires `FLY_API_TOKEN` secret set in repository settings

## Test plan
- [ ] Add `FLY_API_TOKEN` secret to GitHub → Settings → Secrets and variables → Actions
- [ ] Merge this PR into `main`
- [ ] Publish a GitHub release and verify the workflow runs and deploys successfully to Fly.io app `projectmiddleware`

🤖 Generated with [Claude Code](https://claude.com/claude-code)