### PR TITLE
Fix Dockerfile base images to use non-deprecated versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM gradle:7.5-jdk17 AS build
+FROM gradle:8.5-jdk17 AS build
 WORKDIR /app
 COPY . .
 RUN ./gradlew clean shadowJar --no-daemon
 
-FROM openjdk:17-jdk-alpine AS runtime
+FROM eclipse-temurin:17-jre-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/build/libs/ProjectMiddleware-all.jar app.jar
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- Replaces deprecated `gradle:7.5-jdk17` with `gradle:8.5-jdk17`
- Replaces removed `openjdk:17-jdk-alpine` with `eclipse-temurin:17-jre-alpine` (the official successor — JRE-only, smaller footprint)

These images were causing the Fly.io CD pipeline deploy to fail at the Docker build step.

## Test plan
- [ ] Publish a new GitHub release and verify the deploy workflow builds and deploys successfully on Fly.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)