### PR TITLE
feat: switch documentation to Just-the-Docs theme

### DIFF
--- a/documentation/Gemfile
+++ b/documentation/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
-gem "jekyll-theme-chirpy", "~> 7.2"
+gem "just-the-docs"
 
 group :jekyll_plugins do
   gem "jekyll-sitemap"

--- a/documentation/Gemfile.lock
+++ b/documentation/Gemfile.lock
@@ -43,27 +43,22 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-archives (2.3.0)
-      jekyll (>= 3.6, < 5.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-paginate (1.1.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.9.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-theme-chirpy (7.5.0)
-      jekyll (~> 4.3)
-      jekyll-archives (~> 2.2)
-      jekyll-include-cache (~> 0.2)
-      jekyll-paginate (~> 1.1)
-      jekyll-seo-tag (~> 2.8)
-      jekyll-sitemap (~> 1.4)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.19.8)
+    just-the-docs (0.12.0)
+      jekyll (>= 3.8.5)
+      jekyll-include-cache
+      jekyll-seo-tag (>= 2.0)
+      rake (>= 12.3.1)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
@@ -102,7 +97,7 @@ DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-seo-tag (~> 2.8)
   jekyll-sitemap
-  jekyll-theme-chirpy (~> 7.2)
+  just-the-docs
 
 BUNDLED WITH
    2.4.10

--- a/documentation/_config.yml
+++ b/documentation/_config.yml
@@ -1,10 +1,9 @@
-theme: jekyll-theme-chirpy
+theme: just-the-docs
 
 # -------------------------
 # Site metadata
 # -------------------------
 title: "Project Middleware"
-tagline: A Kotlin/Ktor middleware for transforming and mapping external API responses
 description: >-
   ProjectMiddleware is an API transformation layer that lets clients register
   mapping rules, call external APIs, and receive clean transformed responses —
@@ -17,36 +16,15 @@ lang: en
 timezone: America/Sao_Paulo
 
 # -------------------------
-# Author
+# Just-the-Docs settings
 # -------------------------
-github:
-  username: "LeonardoBai12"
+color_scheme: dark
+search_enabled: true
+heading_anchors: true
 
-social:
-  name: "Leonardo Bai"
-  email: "lb.io.dev@gmail.com"
-  links:
-    - https://github.com/LeonardoBai12
-
-# -------------------------
-# Theme preferences
-# -------------------------
-theme_mode:      # leave blank to follow system default; or "light" / "dark"
-
-avatar: "/assets/images/middleware-icon.jpg"
-
-toc: true
-
-# -------------------------
-# Analytics (optional)
-# -------------------------
-google_analytics:
-  id: ""
-
-# -------------------------
-# SEO
-# -------------------------
-google_site_verification: ""
+aux_links:
+  "GitHub":
+    - "https://github.com/LeonardoBai12/ProjectMiddleware"
 
 # -------------------------
 # Jekyll build settings

--- a/documentation/about/index.md
+++ b/documentation/about/index.md
@@ -1,6 +1,7 @@
 ---
-layout: page
+layout: default
 title: About the Creator
+nav_order: 7
 ---
 
 <div style="display:flex; align-items:center; gap:2rem; flex-wrap:wrap; margin-bottom:2rem;">

--- a/documentation/about/index.md
+++ b/documentation/about/index.md
@@ -5,7 +5,7 @@ nav_order: 7
 ---
 
 <div style="display:flex; align-items:center; gap:2rem; flex-wrap:wrap; margin-bottom:2rem;">
-  <img src="/assets/images/perfil.jpeg"
+  <img src="{{ site.baseurl }}/assets/images/perfil.jpeg"
        alt="Leonardo Bai"
        width="140"
        style="border-radius:50%; object-fit:cover; flex-shrink:0;">

--- a/documentation/api-reference/index.md
+++ b/documentation/api-reference/index.md
@@ -1,6 +1,7 @@
 ---
-layout: page
+layout: default
 title: KDoc Reference
+nav_order: 6
 ---
 
 The KDoc reference is auto-generated from the source code on every push to `main` using [Dokka](https://github.com/Kotlin/dokka). It documents all public and internal declarations across every module.

--- a/documentation/ecosystem/index.md
+++ b/documentation/ecosystem/index.md
@@ -1,6 +1,7 @@
 ---
-layout: page
+layout: default
 title: Ecosystem
+nav_order: 5
 ---
 
 ProjectMiddleware is the backend engine of a small ecosystem of services and apps designed to work together. Each piece has a single responsibility and evolves independently.

--- a/documentation/ecosystem/index.md
+++ b/documentation/ecosystem/index.md
@@ -14,7 +14,7 @@ ProjectMiddleware is the backend engine of a small ecosystem of services and app
 
 A **Kotlin Multiplatform** client application for Android and iOS that provides a visual interface for creating, previewing, and managing mapped routes — all powered by ProjectMiddleware on the backend.
 
-![Playground icon](/assets/images/middleware-playground-icon.png){: width="80" style="border-radius:12px; margin-bottom:0.5rem;"}
+![Playground icon]({{ site.baseurl }}/assets/images/middleware-playground-icon.png){: width="80" style="border-radius:12px; margin-bottom:0.5rem;"}
 
 ### What it does
 

--- a/documentation/endpoints/index.md
+++ b/documentation/endpoints/index.md
@@ -1,6 +1,8 @@
 ---
-layout: page
+layout: default
 title: Endpoints Overview
+nav_order: 4
+has_children: true
 ---
 
 All endpoints are served under the base URL of the deployed middleware instance. Authentication with the middleware itself uses HTTP Basic Auth on all routes.

--- a/documentation/endpoints/postman.md
+++ b/documentation/endpoints/postman.md
@@ -1,6 +1,8 @@
 ---
-layout: page
+layout: default
 title: Postman Collection
+parent: Endpoints Overview
+nav_order: 1
 ---
 
 The ProjectMiddleware Postman collection contains ready-to-use requests for all endpoints, with pre-filled examples for route creation, preview, and calling mapped routes.

--- a/documentation/getting-started/index.md
+++ b/documentation/getting-started/index.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Getting Started
+nav_order: 3
+has_children: true
+---
+
+# Getting Started
+
+Learn how to register mapping rules, call external APIs, and receive transformed responses through ProjectMiddleware.

--- a/documentation/getting-started/mapping-request/index.md
+++ b/documentation/getting-started/mapping-request/index.md
@@ -1,6 +1,8 @@
 ---
-layout: page
+layout: default
 title: Mapping Request
+parent: Getting Started
+nav_order: 1
 ---
 
 `POST /v1/mapping` registers a new mapped route. The middleware validates the mapping rules, makes a live test call to the external API, stores the route on success, and returns the UUID-based path to use for all future calls.

--- a/documentation/getting-started/mapping-rules/index.md
+++ b/documentation/getting-started/mapping-rules/index.md
@@ -1,6 +1,8 @@
 ---
-layout: page
+layout: default
 title: Mapping Rules
+parent: Getting Started
+nav_order: 2
 ---
 
 Mapping rules define how the middleware transforms an external API's JSON response into your desired output shape. They are provided as the `rulesAsString` field when creating a mapped route.

--- a/documentation/getting-started/preview-route/index.md
+++ b/documentation/getting-started/preview-route/index.md
@@ -1,6 +1,8 @@
 ---
-layout: page
+layout: default
 title: Preview Route
+parent: Getting Started
+nav_order: 3
 ---
 
 `POST /v1/preview` lets you test mapping rules against a sample response body **without** registering a permanent route or making any outbound calls. Use it to iterate on your `rulesAsString` until the output looks exactly right.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,6 +1,7 @@
 ---
-layout: page
-title: ProjectMiddleware
+layout: home
+title: Home
+nav_order: 1
 ---
 
 **ProjectMiddleware** is a Kotlin/Ktor API transformation service. It acts as a middleware layer: clients register mapping rules that define how to call an external API and how to transform its JSON response. Mapped routes are then served dynamically via UUID-based paths.

--- a/documentation/overview/index.md
+++ b/documentation/overview/index.md
@@ -1,6 +1,8 @@
 ---
-layout: page
+layout: default
 title: How It Works
+nav_order: 2
+has_children: true
 ---
 
 ProjectMiddleware sits between your client application and any external API. You define the transformation rules once, and the middleware handles all subsequent calls — including authentication, field mapping, and response shaping.

--- a/documentation/overview/key-features.md
+++ b/documentation/overview/key-features.md
@@ -1,6 +1,8 @@
 ---
-layout: page
+layout: default
 title: Key Features
+parent: How It Works
+nav_order: 1
 ---
 
 ## Flexible field mapping


### PR DESCRIPTION
## Summary
- Replaces Chirpy blog theme with Just-the-Docs documentation theme
- Updates `_config.yml` and `Gemfile` to use `just-the-docs` gem
- Adds nav hierarchy via front matter (`parent`, `nav_order`, `has_children`) across all pages
- Creates missing `getting-started/index.md` as parent page for mapping-request, mapping-rules, and preview-route sections
- Fixes image paths to use `{{ site.baseurl }}` prefix for correct loading on both local dev and GitHub Pages

## Test plan
- [ ] Serve locally with `bundle exec jekyll serve --baseurl ""` from `documentation/`
- [ ] Verify sidebar: Home → How It Works → Getting Started → Endpoints → Ecosystem → KDoc Reference → About
- [ ] Confirm profile photo loads on About page
- [ ] Confirm Playground icon loads on Ecosystem page

🤖 Generated with [Claude Code](https://claude.com/claude-code)